### PR TITLE
ETags should be double-quoted

### DIFF
--- a/src/LaravelConditionalMiddleware.php
+++ b/src/LaravelConditionalMiddleware.php
@@ -86,7 +86,7 @@ class LaravelConditionalMiddleware
         $response = $next($request);
 
         if ($processETag) {
-            $response->header('ETag', $eTag);
+            $response->header('ETag', json_encode($eTag));
         }
 
         if ($processLastModified) {
@@ -105,8 +105,9 @@ class LaravelConditionalMiddleware
         }
 
         $found = collect(explode(',', $header))
-            ->map(fn ($tag) => trim($tag, "\" \n\r\t\v\x00"))
+            ->map('trim')
             ->reject(fn ($tag) => Str::startsWith($tag, 'W/'))
+            ->map(fn ($tag) => trim($tag, '"'))
             ->search($eTag);
 
         return $found !== false;

--- a/tests/IfMatchTest.php
+++ b/tests/IfMatchTest.php
@@ -12,7 +12,7 @@ class IfMatchTest extends TestCase
     {
         $eTag = $this->returnETag('abcdefg');
         $response = $this->get('/test');
-        $response->assertHeader('ETag', $eTag);
+        $response->assertHeader('ETag', json_encode($eTag));
 
         Event::assertDispatched(TestEvent::class);
     }

--- a/tests/IfNoneMatchTest.php
+++ b/tests/IfNoneMatchTest.php
@@ -12,7 +12,7 @@ class IfNoneMatchTest extends TestCase
     {
         $eTag = $this->returnETag('abcdefg');
         $response = $this->get('/test');
-        $response->assertHeader('ETag', $eTag);
+        $response->assertHeader('ETag', json_encode($eTag));
 
         Event::assertDispatched(TestEvent::class);
     }
@@ -35,7 +35,7 @@ class IfNoneMatchTest extends TestCase
             'If-None-Match' => '1234567',
         ])->get('/test');
         $response->assertStatus(200);
-        $response->assertHeader('ETag', $eTag);
+        $response->assertHeader('ETag', json_encode($eTag));
 
         Event::assertDispatched(TestEvent::class);
     }


### PR DESCRIPTION
ETags look like this in a request: `"1234", W/"23546"`. The Weak modifier is before the quoted string.